### PR TITLE
Splat size changes

### DIFF
--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -134,7 +134,7 @@ public class PlayerController : MonoBehaviour
                     if (!otherPlayer.PlayerStun.Stunned)
                         StartCoroutine(otherPlayer.PlayerStun.Stun(dashAmount));
 
-                    Splat();
+                    Splat(dashAmount);
                 }
             }
         }
@@ -145,7 +145,7 @@ public class PlayerController : MonoBehaviour
                 if (!PlayerStun.Stunned)
                 {
                     StartCoroutine(PlayerStun.Stun(dashAmount));
-                    Splat();
+                    Splat(dashAmount);
                 }
             }
         }
@@ -223,7 +223,7 @@ public class PlayerController : MonoBehaviour
         }
     }
 
-    public void Splat()
+    public void Splat(float multiplier = 1)
     {
         Ray ray = new Ray(transform.position, -transform.up);
 
@@ -237,9 +237,9 @@ public class PlayerController : MonoBehaviour
 
                 float _smult;
                 if (paintMultiplier)
-                    _smult = paintMultiplier.multiplier * weaponSplashMultiplier;
+                    _smult = paintMultiplier.multiplier * multiplier;
                 else
-                    _smult = 1f * weaponSplashMultiplier;
+                    _smult = 1f * multiplier;
 
                 int _id = Player.playerNum;
                 for (int i = 0; i < 10; i++)
@@ -253,7 +253,7 @@ public class PlayerController : MonoBehaviour
         {
             if (hit.collider.CompareTag("ScoreGrid"))
             {
-                Collider[] squaresHit = Physics.OverlapSphere(hit.collider.gameObject.transform.position, 6);
+                Collider[] squaresHit = Physics.OverlapSphere(hit.collider.gameObject.transform.position, 6 * multiplier);
 
                 for (int i = 0; i < squaresHit.Length; i++)
                 {

--- a/Assets/Scripts/Powerups/SplatRelease.cs
+++ b/Assets/Scripts/Powerups/SplatRelease.cs
@@ -18,7 +18,7 @@ public class SplatRelease : BuffDebuff
         base.OnUpdate(deltaTime);
         //If the player releases the dash button and isn't dashing, run the splat method
         if (Input.GetButtonUp($"Dash{Parent.Player.playerNum}") && !Parent.IsDashing)
-            Parent.Splat();
+            Parent.Splat(0.5f);
     }
 
     public override void End()

--- a/Assets/Scripts/Powerups/TrailPowerup.cs
+++ b/Assets/Scripts/Powerups/TrailPowerup.cs
@@ -19,7 +19,7 @@ public class TrailPowerup : BuffDebuff
         //Whenever the elapsed time can be divided by 0.25 with a remainder that is less than 0.1 (e.g. 6.253 % = 0.003)
         //and if the player is moving, call the splat method
         if (elapsedTime % 0.25 < 0.1 && Parent.MoveVelocity != Vector3.zero)
-            Parent.Splat();
+            Parent.Splat(0.25f);
     }
 
     public override void End()


### PR DESCRIPTION
Changed the sizes of various splats:

• Splats when colliding with players/objects now scale based on the charge power
• Trail is now 25% of the size of a full splat
• Splat release is now 50% of the size of a full splat