### PR TITLE
Pin Reset fix, and some adjustments to menu

### DIFF
--- a/Assets/Scripts/UI/MainMenu/CharacterPin.cs
+++ b/Assets/Scripts/UI/MainMenu/CharacterPin.cs
@@ -52,6 +52,7 @@ public class CharacterPin : MonoBehaviour
     public void UnOwnPin()
     {
         characterSprite.sprite = unSelectedImage;
+        ownedBy = null;
     }
 
     public Transform TakeDirection(string direction, int playerPos)

--- a/Assets/Scripts/UI/MainMenu/LevelSelector.cs
+++ b/Assets/Scripts/UI/MainMenu/LevelSelector.cs
@@ -34,22 +34,29 @@ public class LevelSelector : MonoBehaviour
     private float waitBetweenAnimation = 0.5f;
     [SerializeField]
     private float animationSpeed = 0.5f;
+    private PinReset resetPin;
 
     private void OnEnable()
     {
+        resetPin = GameObject.Find("ScriptControl").GetComponent<PinReset>();
+        resetPin.CallReset();
         levelIndex = 0;
-        StopCoroutine("OpenFridge");
-        StartCoroutine(OpenFridge());
         canPressButton = true;
         isAxis = false;
         inTransition = false;
+        StartCoroutine("OpenFridge");
     }
+
+
 
     private void Update()
     {
-        if (Input.GetButtonDown("Dash"))
+        if (inTransition == false)
         {
-            SelectLevel();
+            if (Input.GetButtonDown("Dash"))
+            {
+                SelectLevel();
+            }
         }
         if (Input.GetButton("BackButton"))
         {
@@ -72,6 +79,22 @@ public class LevelSelector : MonoBehaviour
                     if (levelIndex == levelViewPoints.Length)
                     {
                         levelIndex = 0;
+                    }
+                    CameraMovement();
+                }
+            }
+        }
+        else  if (Input.GetAxis("Horizontal") < -0.5f)
+        {
+            if (isAxis == false)
+            {
+                if (canPressButton == true)
+                {
+                    isAxis = true;
+                    levelIndex--;
+                    if (levelIndex < 0)
+                    {
+                        levelIndex = levelViewPoints.Length;
                     }
                     CameraMovement();
                 }
@@ -134,7 +157,7 @@ public class LevelSelector : MonoBehaviour
 
     private IEnumerator OpenFridge()
     {
-        yield return new WaitForSeconds(0.7f);
+        yield return new WaitForEndOfFrame();
         doorAnimation.enabled = true;
         doorAnimation.speed = animationSpeed;
         doorAnimation.SetInteger("CloseAnim", 1);
@@ -148,7 +171,7 @@ public class LevelSelector : MonoBehaviour
 
     private IEnumerator CloseFridge()
     {
-        yield return new WaitForSeconds(0.7f);
+        yield return new WaitForEndOfFrame();
         doorAnimation.enabled = true;
         doorAnimation.speed = animationSpeed;
         doorAnimation.SetInteger("CloseAnim", 2);
@@ -156,7 +179,7 @@ public class LevelSelector : MonoBehaviour
         inTransition = true;
         yield return new WaitForSeconds(waitBetweenAnimation);
         inTransition = false;
-        yield return new WaitForSeconds(4);
+      //  yield return new WaitForSeconds(4);
         ReturnToCharacterSelect();
     }
 

--- a/Assets/Scripts/UI/MainMenu/NewCharacterSelectionController.cs
+++ b/Assets/Scripts/UI/MainMenu/NewCharacterSelectionController.cs
@@ -34,6 +34,8 @@ public class NewCharacterSelectionController : MonoBehaviour
     [SerializeField]
     private float cameraMoveSpeed = 0.2f;
     [SerializeField]
+    private float goToLevelDelay = 0.2f;
+    [SerializeField]
     private bool usingLerp = true;
     [SerializeField]
     private Transform[] pinLocations, playerPins;
@@ -98,9 +100,9 @@ public class NewCharacterSelectionController : MonoBehaviour
         {
             doorAnimation.enabled = false;
         }
-        canPressBtn = false;
+        canPressBtn = true;
         isTransition = false;
-       // ResetPlayers();
+        isConfirmation = false;
     }
 
     private void OnEnable()
@@ -109,10 +111,14 @@ public class NewCharacterSelectionController : MonoBehaviour
         doorAnimation.enabled = false;
         canPressBtn = true;
         isTransition = false;
+        isConfirmation = false;
         ResetPlayers();
-        //ReadyCancel();
-        canPressBtn = true;
-        isTransition = false;   
+        //ReadyCancel();  
+    }
+
+    private void ResetSoft()
+    {
+        Debug.Log("Ran at end of door opening!");
     }
 
     private void ResetPlayers()
@@ -206,7 +212,7 @@ public class NewCharacterSelectionController : MonoBehaviour
     //Coroutine for going to the level select
     private IEnumerator GoToLevelSelect()
     {
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(goToLevelDelay);
         readyImage2.SetActive(false);
         //Call method for enabling level select UI
         MenuController.instance.CharacterSelectionToLevelSelect();

--- a/Assets/Scripts/UI/MainMenu/NewMainMenu.cs
+++ b/Assets/Scripts/UI/MainMenu/NewMainMenu.cs
@@ -147,7 +147,7 @@ public class NewMainMenu : MonoBehaviour
             {
                 cameraTransform.position = Vector3.MoveTowards(cameraTransform.position, characterSelectPoint.position, cameraSpeedMedals * Time.deltaTime);
             }
-            cameraTransform.rotation = Quaternion.Slerp(cameraTransform.rotation, characterSelectPoint.rotation, cameraSpeedMedals * Time.deltaTime);
+            cameraTransform.rotation = Quaternion.Slerp(cameraTransform.rotation, characterSelectPoint.rotation, (cameraSpeedMedals + 0.2f) * Time.deltaTime);
             if (Vector3.Distance(cameraTransform.position, characterSelectPoint.position) < 0.01f) arrived = true;
             yield return null;
         }

--- a/Assets/Scripts/UI/MainMenu/PinController.cs
+++ b/Assets/Scripts/UI/MainMenu/PinController.cs
@@ -37,12 +37,23 @@ public class PinController : MonoBehaviour
 
     private void OnEnable()
     {
+        pin.gameObject.SetActive(false);
+        pin.position = defaultPinLocation.position;
+        pin.gameObject.SetActive(true);
         isLocked = false;
         isPinMoving = false;
         isOnFridge = false;
         target = null;
         isActive = false;
-        pin.position = defaultPinLocation.position;
+        
+    }
+
+    private void OnDisable()
+    {
+       /* isPinMoving = false;
+        isOnFridge = false;
+        target = null;
+        isActive = false;*/
     }
 
     private void Start()
@@ -279,7 +290,6 @@ public class PinController : MonoBehaviour
             // Debug.Log(target.parent.name);
             if (target != null)
             {
-                Debug.Log(target);
                 if (target.GetComponentInParent<CharacterPin>() != null)
                 {
                     target.GetComponentInParent<CharacterPin>().UnOwnPin();

--- a/Assets/Scripts/UI/PinReset.cs
+++ b/Assets/Scripts/UI/PinReset.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PinReset : MonoBehaviour
+{
+    [SerializeField]
+    private Transform[] pinLoc;
+    [SerializeField]
+    private Transform[] pin;
+    [SerializeField]
+    private CharacterPin[] pinImg;
+    [SerializeField]
+    private float resetDelayTime = 0.1f;
+
+
+    public void CallReset()
+    {
+        StopCoroutine("ResetDelay");
+        StartCoroutine("ResetDelay");
+    }
+    private void ResetMode()
+    {
+        for (int i = 0; i < pin.Length; i++)
+        {
+            pin[i].transform.position = pinLoc[i].transform.position;
+        }
+        for (int i = 0; i < pinImg.Length; i++)
+        {
+            pinImg[i].UnOwnPin();
+        }
+    }
+
+    private IEnumerator ResetDelay()
+    {
+        yield return new WaitForSeconds(resetDelayTime);
+        ResetMode();
+        yield return null;
+    }
+
+}

--- a/Assets/Scripts/UI/PinReset.cs.meta
+++ b/Assets/Scripts/UI/PinReset.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6305d0ef20220b4095e2083ca084517
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scenes/NewMainMenu.unity
+++ b/Assets/_Scenes/NewMainMenu.unity
@@ -480,11 +480,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 2227314580439173190, guid: 151be385fce02a54ca91dd5a2f3d3213,
-        type: 3}
-      propertyPath: m_Name
-      value: JuiceCarton_Current_MM
-      objectReference: {fileID: 0}
     - target: {fileID: 2932506464091568725, guid: 151be385fce02a54ca91dd5a2f3d3213,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -549,6 +544,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 0.1000002
+      objectReference: {fileID: 0}
+    - target: {fileID: 2227314580439173190, guid: 151be385fce02a54ca91dd5a2f3d3213,
+        type: 3}
+      propertyPath: m_Name
+      value: JuiceCarton_Current_MM
       objectReference: {fileID: 0}
     - target: {fileID: 492533671869430938, guid: 151be385fce02a54ca91dd5a2f3d3213,
         type: 3}
@@ -1135,11 +1135,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 2227314580439173190, guid: 151be385fce02a54ca91dd5a2f3d3213,
-        type: 3}
-      propertyPath: m_Name
-      value: JuiceCarton_Current_MM (3)
-      objectReference: {fileID: 0}
     - target: {fileID: 2932506464091568725, guid: 151be385fce02a54ca91dd5a2f3d3213,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1194,6 +1189,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2227314580439173190, guid: 151be385fce02a54ca91dd5a2f3d3213,
+        type: 3}
+      propertyPath: m_Name
+      value: JuiceCarton_Current_MM (3)
       objectReference: {fileID: 0}
     - target: {fileID: 492533671869430938, guid: 151be385fce02a54ca91dd5a2f3d3213,
         type: 3}
@@ -7189,11 +7189,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 8298541835999194911, guid: 9dd83afe76a56c7409b51f10c57f99b2,
-        type: 3}
-      propertyPath: m_Name
-      value: BlueSponge_Current_MM
-      objectReference: {fileID: 0}
     - target: {fileID: 5003796114275949836, guid: 9dd83afe76a56c7409b51f10c57f99b2,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7258,6 +7253,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 0.14799829
+      objectReference: {fileID: 0}
+    - target: {fileID: 8298541835999194911, guid: 9dd83afe76a56c7409b51f10c57f99b2,
+        type: 3}
+      propertyPath: m_Name
+      value: BlueSponge_Current_MM
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9dd83afe76a56c7409b51f10c57f99b2, type: 3}
@@ -7616,11 +7616,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 863376570373465849, guid: 0e5eb5e828463254c812817a9ac199e4,
-        type: 3}
-      propertyPath: m_Name
-      value: Sausage_MM
-      objectReference: {fileID: 0}
     - target: {fileID: 30442683350702628, guid: 0e5eb5e828463254c812817a9ac199e4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -7690,6 +7685,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 0.100000024
+      objectReference: {fileID: 0}
+    - target: {fileID: 863376570373465849, guid: 0e5eb5e828463254c812817a9ac199e4,
+        type: 3}
+      propertyPath: m_Name
+      value: Sausage_MM
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e5eb5e828463254c812817a9ac199e4, type: 3}
@@ -8034,11 +8034,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 1219000045222739397, guid: 50767bd441a00a342a5f1725520ea015,
-        type: 3}
-      propertyPath: m_Name
-      value: Duck_Current_MM
-      objectReference: {fileID: 0}
     - target: {fileID: 2788180952499179478, guid: 50767bd441a00a342a5f1725520ea015,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -8103,6 +8098,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 0.100000024
+      objectReference: {fileID: 0}
+    - target: {fileID: 1219000045222739397, guid: 50767bd441a00a342a5f1725520ea015,
+        type: 3}
+      propertyPath: m_Name
+      value: Duck_Current_MM
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 50767bd441a00a342a5f1725520ea015, type: 3}
@@ -10211,7 +10211,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &565220996
 Transform:
   m_ObjectHideFlags: 0
@@ -12496,11 +12496,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 2227314580439173190, guid: 151be385fce02a54ca91dd5a2f3d3213,
-        type: 3}
-      propertyPath: m_Name
-      value: JuiceCarton_Current_MM
-      objectReference: {fileID: 0}
     - target: {fileID: 2932506464091568725, guid: 151be385fce02a54ca91dd5a2f3d3213,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -12555,6 +12550,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2227314580439173190, guid: 151be385fce02a54ca91dd5a2f3d3213,
+        type: 3}
+      propertyPath: m_Name
+      value: JuiceCarton_Current_MM
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 151be385fce02a54ca91dd5a2f3d3213, type: 3}
@@ -12665,11 +12665,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1687631734}
     m_Modifications:
-    - target: {fileID: 863376570373465849, guid: 0e5eb5e828463254c812817a9ac199e4,
-        type: 3}
-      propertyPath: m_Name
-      value: Sausage_MM (6)
-      objectReference: {fileID: 0}
     - target: {fileID: 30442683350702628, guid: 0e5eb5e828463254c812817a9ac199e4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -12724,6 +12719,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 863376570373465849, guid: 0e5eb5e828463254c812817a9ac199e4,
+        type: 3}
+      propertyPath: m_Name
+      value: Sausage_MM (6)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e5eb5e828463254c812817a9ac199e4, type: 3}
@@ -12951,11 +12951,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 3575249518214745668, guid: e395860ec9b85ed4f93d50e91df94358,
-        type: 3}
-      propertyPath: m_Name
-      value: Fog Ssytem
-      objectReference: {fileID: 0}
     - target: {fileID: 3575249518214745665, guid: e395860ec9b85ed4f93d50e91df94358,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -13025,6 +13020,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 0.09218227
+      objectReference: {fileID: 0}
+    - target: {fileID: 3575249518214745668, guid: e395860ec9b85ed4f93d50e91df94358,
+        type: 3}
+      propertyPath: m_Name
+      value: Fog Ssytem
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e395860ec9b85ed4f93d50e91df94358, type: 3}
@@ -15120,7 +15120,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1071786733
 Transform:
   m_ObjectHideFlags: 0
@@ -15165,7 +15165,7 @@ MonoBehaviour:
   defaultCameraPoint: {fileID: 2016102947}
   controlsCameraPoint: {fileID: 1798007094}
   usingLerp: 1
-  waitBetweenAnimation: 1
+  waitBetweenAnimation: 0.05
   cameraMoveSpeed: 6
   animationSpeed: 6
   cameraSpeedMedals: 6
@@ -21084,11 +21084,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 8547275618353600747, guid: de36d2c10dc713d4fb8eab3d9778a259,
-        type: 3}
-      propertyPath: m_Name
-      value: Curtains_Current (1)
-      objectReference: {fileID: 0}
     - target: {fileID: 4667237998835018488, guid: de36d2c10dc713d4fb8eab3d9778a259,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -21159,6 +21154,11 @@ PrefabInstance:
       propertyPath: m_LocalScale.z
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 8547275618353600747, guid: de36d2c10dc713d4fb8eab3d9778a259,
+        type: 3}
+      propertyPath: m_Name
+      value: Curtains_Current (1)
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: de36d2c10dc713d4fb8eab3d9778a259, type: 3}
 --- !u!4 &1175175494 stripped
@@ -21183,7 +21183,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1199223332
 Transform:
   m_ObjectHideFlags: 0
@@ -21223,7 +21223,7 @@ MonoBehaviour:
   inTransition: 0
   doorAnimation: {fileID: 836192792}
   waitBetweenAnimation: 0.5
-  animationSpeed: 0.5
+  animationSpeed: 1
 --- !u!1001 &1226005636
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -21698,11 +21698,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1687631734}
     m_Modifications:
-    - target: {fileID: 863376570373465849, guid: 0e5eb5e828463254c812817a9ac199e4,
-        type: 3}
-      propertyPath: m_Name
-      value: Sausage_MM (4)
-      objectReference: {fileID: 0}
     - target: {fileID: 30442683350702628, guid: 0e5eb5e828463254c812817a9ac199e4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -21757,6 +21752,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 863376570373465849, guid: 0e5eb5e828463254c812817a9ac199e4,
+        type: 3}
+      propertyPath: m_Name
+      value: Sausage_MM (4)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e5eb5e828463254c812817a9ac199e4, type: 3}
@@ -22515,6 +22515,16 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4259726570698521952, guid: 6bbf727faf0490d499f0716a71dc7d18,
+        type: 3}
+      propertyPath: m_Text
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1112254296294081485, guid: 6bbf727faf0490d499f0716a71dc7d18,
+        type: 3}
+      propertyPath: m_FillAmount
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8445408346885361946, guid: 6bbf727faf0490d499f0716a71dc7d18,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -22624,16 +22634,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -5
-      objectReference: {fileID: 0}
-    - target: {fileID: 4259726570698521952, guid: 6bbf727faf0490d499f0716a71dc7d18,
-        type: 3}
-      propertyPath: m_Text
-      value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1112254296294081485, guid: 6bbf727faf0490d499f0716a71dc7d18,
-        type: 3}
-      propertyPath: m_FillAmount
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 6bbf727faf0490d499f0716a71dc7d18, type: 3}
@@ -29334,11 +29334,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1687631734}
     m_Modifications:
-    - target: {fileID: 863376570373465849, guid: 0e5eb5e828463254c812817a9ac199e4,
-        type: 3}
-      propertyPath: m_Name
-      value: Sausage_MM (5)
-      objectReference: {fileID: 0}
     - target: {fileID: 30442683350702628, guid: 0e5eb5e828463254c812817a9ac199e4,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -29393,6 +29388,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 863376570373465849, guid: 0e5eb5e828463254c812817a9ac199e4,
+        type: 3}
+      propertyPath: m_Name
+      value: Sausage_MM (5)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e5eb5e828463254c812817a9ac199e4, type: 3}
@@ -30503,11 +30503,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 2636577275008761382, guid: 5240eb6e7e3f0b44a9f90bc17f667b64,
-        type: 3}
-      propertyPath: m_Name
-      value: RollingPin_Current_MM
-      objectReference: {fileID: 0}
     - target: {fileID: 1354555268714023989, guid: 5240eb6e7e3f0b44a9f90bc17f667b64,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -30572,6 +30567,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 0.09999999
+      objectReference: {fileID: 0}
+    - target: {fileID: 2636577275008761382, guid: 5240eb6e7e3f0b44a9f90bc17f667b64,
+        type: 3}
+      propertyPath: m_Name
+      value: RollingPin_Current_MM
       objectReference: {fileID: 0}
     - target: {fileID: 590134904809923592, guid: 5240eb6e7e3f0b44a9f90bc17f667b64,
         type: 3}
@@ -41961,7 +41961,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1966571986
 Transform:
   m_ObjectHideFlags: 0
@@ -42004,6 +42004,7 @@ MonoBehaviour:
   waitBetweenAnimation: 0.2
   animationSpeed: 0.5
   cameraMoveSpeed: 5
+  goToLevelDelay: 0.8
   usingLerp: 1
   pinLocations:
   - {fileID: 1639363636}
@@ -42208,11 +42209,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 8117674160128078250, guid: 7d07685f1beb9e843b68615777f546a2,
-        type: 3}
-      propertyPath: m_Name
-      value: SoapBar_Current_MM
-      objectReference: {fileID: 0}
     - target: {fileID: 5115135330011038649, guid: 7d07685f1beb9e843b68615777f546a2,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -42282,6 +42278,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.y
       value: 0.15
+      objectReference: {fileID: 0}
+    - target: {fileID: 8117674160128078250, guid: 7d07685f1beb9e843b68615777f546a2,
+        type: 3}
+      propertyPath: m_Name
+      value: SoapBar_Current_MM
       objectReference: {fileID: 0}
     - target: {fileID: 7537640044100519286, guid: 7d07685f1beb9e843b68615777f546a2,
         type: 3}
@@ -48999,6 +49000,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2110605044}
   - component: {fileID: 2110605045}
+  - component: {fileID: 2110605046}
   m_Layer: 0
   m_Name: ScriptControl
   m_TagString: Untagged
@@ -49041,6 +49043,36 @@ MonoBehaviour:
   characterSelectScript: {fileID: 1966571986}
   loadingPage: {fileID: 1380790324}
   levelSelectScript: {fileID: 1199223332}
+--- !u!114 &2110605046
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2110605043}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6305d0ef20220b4095e2083ca084517, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  pinLoc:
+  - {fileID: 146763326}
+  - {fileID: 1865517782}
+  - {fileID: 1547007830}
+  - {fileID: 2056856458}
+  pin:
+  - {fileID: 1639363636}
+  - {fileID: 1120957415}
+  - {fileID: 213736204}
+  - {fileID: 751649592}
+  pinImg:
+  - {fileID: 1423579650}
+  - {fileID: 1776992725}
+  - {fileID: 1127358226}
+  - {fileID: 2074459657}
+  - {fileID: 167047500}
+  - {fileID: 1767483054}
+  resetDelayTime: 4
 --- !u!23 &8432209260609354
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -50684,11 +50716,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1396707604}
     m_Modifications:
-    - target: {fileID: 5877773023182915392, guid: 74e29a7a4977c2d47b7b851986875b7a,
-        type: 3}
-      propertyPath: m_Name
-      value: PlainWall_Current (2)
-      objectReference: {fileID: 0}
     - target: {fileID: 7478599592807232851, guid: 74e29a7a4977c2d47b7b851986875b7a,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -50743,6 +50770,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5877773023182915392, guid: 74e29a7a4977c2d47b7b851986875b7a,
+        type: 3}
+      propertyPath: m_Name
+      value: PlainWall_Current (2)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 74e29a7a4977c2d47b7b851986875b7a, type: 3}
@@ -52349,11 +52381,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 824085859876955116, guid: 719ecec7f31c5a24d8e31db36638ab6e,
-        type: 3}
-      propertyPath: m_Name
-      value: toaster_current
-      objectReference: {fileID: 0}
     - target: {fileID: 4410401043619615231, guid: 719ecec7f31c5a24d8e31db36638ab6e,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -52408,6 +52435,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 824085859876955116, guid: 719ecec7f31c5a24d8e31db36638ab6e,
+        type: 3}
+      propertyPath: m_Name
+      value: toaster_current
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 719ecec7f31c5a24d8e31db36638ab6e, type: 3}
@@ -52788,11 +52820,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 6553831039186996429, guid: 4894da36865017745add56df71f5a492,
-        type: 3}
-      propertyPath: m_Name
-      value: DiningChair_Current (1)
-      objectReference: {fileID: 0}
     - target: {fileID: 7829713851560853214, guid: 4894da36865017745add56df71f5a492,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -52862,6 +52889,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6553831039186996429, guid: 4894da36865017745add56df71f5a492,
+        type: 3}
+      propertyPath: m_Name
+      value: DiningChair_Current (1)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4894da36865017745add56df71f5a492, type: 3}
@@ -52994,11 +53026,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 4250225251578324472, guid: 9c084be8745a09d43895160227086f73,
-        type: 3}
-      propertyPath: m_Name
-      value: DiningTable_Current (1)
-      objectReference: {fileID: 0}
     - target: {fileID: 909881606384015339, guid: 9c084be8745a09d43895160227086f73,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -53068,6 +53095,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalScale.z
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4250225251578324472, guid: 9c084be8745a09d43895160227086f73,
+        type: 3}
+      propertyPath: m_Name
+      value: DiningTable_Current (1)
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9c084be8745a09d43895160227086f73, type: 3}
@@ -53170,11 +53202,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 2081889171}
     m_Modifications:
-    - target: {fileID: 4966190446174769234, guid: 6322cc7cec53bac4789ee7e7d025a298,
-        type: 3}
-      propertyPath: m_Name
-      value: CakeStand_Current
-      objectReference: {fileID: 0}
     - target: {fileID: 8264151766174097985, guid: 6322cc7cec53bac4789ee7e7d025a298,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -53230,6 +53257,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4966190446174769234, guid: 6322cc7cec53bac4789ee7e7d025a298,
+        type: 3}
+      propertyPath: m_Name
+      value: CakeStand_Current
+      objectReference: {fileID: 0}
     - target: {fileID: 3549440832482040641, guid: 6322cc7cec53bac4789ee7e7d025a298,
         type: 3}
       propertyPath: m_CastShadows
@@ -53258,11 +53290,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1396707604}
     m_Modifications:
-    - target: {fileID: 1584257339658308359, guid: 3d50f318ea6ec3c4ba69cff6dc64d12c,
-        type: 3}
-      propertyPath: m_Name
-      value: Floor_Current
-      objectReference: {fileID: 0}
     - target: {fileID: 2569075374138161428, guid: 3d50f318ea6ec3c4ba69cff6dc64d12c,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -53317,6 +53344,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1584257339658308359, guid: 3d50f318ea6ec3c4ba69cff6dc64d12c,
+        type: 3}
+      propertyPath: m_Name
+      value: Floor_Current
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3d50f318ea6ec3c4ba69cff6dc64d12c, type: 3}


### PR DESCRIPTION
Fixed pins not resetting when returning from level select.
Adjusted speed between transitions and animations between character select to level select and vice versa.
Fixed bug found during fixing pins, where pin would not deallocate its owner when transitioning between any other menu.